### PR TITLE
Use Xcode 14 in GHA workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v3
 
-    - name: Select Xcode 14.1
+    - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
 
     - name: Build and test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v3
 
-    - name: Select Xcode 13.4
-      run: sudo xcode-select -s /Applications/Xcode_13.4.app/Contents/Developer
+    - name: Select Xcode 14.1
+      run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
 
     - name: Build and test
       run: |


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1203301625297703/1203400936495867/f

**Description**:
Set CI to use Xcode version currently used by the team.

**Steps to test this PR**:
1. Verify that CI checks pass for this PR.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
